### PR TITLE
Fix emoji sed string pattern

### DIFF
--- a/.local/bin/bemoji
+++ b/.local/bin/bemoji
@@ -66,7 +66,7 @@ prepare_db() {
 
 download_emoji() {
     curl -sSL "https://unicode.org/Public/emoji/latest/emoji-test.txt" |
-    sed -nE 's/^.*; fully-qualified.*# (.[^ ]*) .*$/\1 \2/p' > "$DB_DIR/emojis.txt"
+    sed -nE 's/^.*; fully-qualified.*# (.[^ ]*) E[0-9.]+ (.*)$/\1 \2/p' > "$DB_DIR/emojis.txt"
 }
 
 download_math() {


### PR DESCRIPTION
When I was trying to get the script to work on my own system, I noted that the current emoji parsing string wasn't correct. I have fixed this (hopefully).

Also, can I use this in my dotfiles? I'll try to remember to credit you in the readme when I eventually get around to pushing it.